### PR TITLE
Use actual font data via Fondue

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,0 @@
-[submodule "src/lib/Font.js"]
-	path = src/lib/Font.js
-	url = https://github.com/RoelN/Font.js
-	branch = base64-support

--- a/package-lock.json
+++ b/package-lock.json
@@ -5225,6 +5225,10 @@
         }
       }
     },
+    "fondue": {
+      "version": "git+ssh://git@github.com/Wakamai-Fondue/old-wakamai-fondue-engine.git#e3388d0c89784ce39db7de435a43d4e185a5f342",
+      "from": "git+ssh://git@github.com/Wakamai-Fondue/old-wakamai-fondue-engine.git#feature/more-font-data"
+    },
     "for-in": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/for-in/-/for-in-1.0.2.tgz",

--- a/package-lock.json
+++ b/package-lock.json
@@ -5226,8 +5226,8 @@
       }
     },
     "fondue": {
-      "version": "git+ssh://git@github.com/Wakamai-Fondue/old-wakamai-fondue-engine.git#e3388d0c89784ce39db7de435a43d4e185a5f342",
-      "from": "git+ssh://git@github.com/Wakamai-Fondue/old-wakamai-fondue-engine.git#feature/more-font-data"
+      "version": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#680bf8f551bb2d682726edcf087db8b0bdfd6f6a",
+      "from": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#master"
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
-    "fondue": "git+ssh://git@github.com/Wakamai-Fondue/old-wakamai-fondue-engine.git#feature/more-font-data",
+    "fondue": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#master",
     "vue": "^2.6.11"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -9,6 +9,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
+    "fondue": "git+ssh://git@github.com/Wakamai-Fondue/old-wakamai-fondue-engine.git#feature/more-font-data",
     "vue": "^2.6.11"
   },
   "devDependencies": {

--- a/src/App.vue
+++ b/src/App.vue
@@ -1,7 +1,7 @@
 <template>
 	<main
 		id="app"
-		@drop.prevent="grabFont"
+		@drop.prevent="getFont"
 		@dragover.prevent="dragging = true"
 		@mouseout="dragging = false"
 		:class="{ dragging }"

--- a/src/components/Report.vue
+++ b/src/components/Report.vue
@@ -1,11 +1,11 @@
 <template>
 	<section v-if="font" class="report" id="report">
 		<Summary :font="font" />
-		<Tester :font="font" />
+		<Tester v-if="font.isVariable" :font="font" />
 		<Color :font="font" />
-		<Variable :font="font" />
+		<Variable v-if="font.isVariable" :font="font" />
 		<Features :font="font" />
-		<Charset :font="font" />
+		<Charset v-if="font.isVariable" :font="font" />
 		<Footer />
 	</section>
 </template>

--- a/src/components/report/Summary.js
+++ b/src/components/report/Summary.js
@@ -1,13 +1,19 @@
 export default {
 	props: ["font"],
-	data: () => ({
-		features: ["abcd", "xxxx", "1234"],
-		name: {
-			name: "Super Duper Sans",
-			copyright: "Roel Nieskens",
-			version: "Version 2.0001",
-			license: "This is the font license",
-			"manufactured by": "Kabisa Inc. Ltd. GmbH"
+	computed: {
+		summary: function() {
+			return this.font.summary;
+		},
+		features: function() {
+			return this.font.features;
+		},
+		fontFormat: function() {
+			return "hello";
 		}
-	})
+	},
+	methods: {
+		featureLength() {
+			return Object.keys(this.features).length;
+		}
+	}
 };

--- a/src/components/report/Summary.vue
+++ b/src/components/report/Summary.vue
@@ -1,18 +1,20 @@
 <template>
 	<section class="summary content" id="summary">
-		<h1>Font name</h1>
+		<h1>{{ summary["Font name"] }}</h1>
 		<p class="oneliner">
 			This is
-			<template v-if="true">an</template>
+
+			<template v-if="font.format == 'OpenType/CFF'">an</template>
 			<template v-else>a</template>
+			&nbsp;
 
-			<strong>{ getFontFormat }</strong>
+			<strong>{{ font.format }}</strong>
+			&nbsp;
 
-			<strong v-if="true">variable</strong>
-			<strong v-if="true">color</strong>
+			<strong v-if="font.isVariable">variable</strong>
+			<strong v-if="font.isColor">color &nbsp;</strong>
 
 			font with
-
 			<strong>{ numCharacters } characters.</strong>
 
 			<template v-if="true">
@@ -27,16 +29,18 @@
 				<strong>{ listColorFormats }</strong>
 				color glyphs.
 			</template>
-
 			It has
-			<strong v-if="true">no</strong>
-			<strong v-else>{ getAvailableFeatures.length }</strong>
-			<strong>layout feature<template v-if="true">s</template></strong
+			<strong v-if="featureLength() === 0">no</strong>
+			<strong v-else>{{ featureLength() }}</strong>
+			<strong>
+				layout feature<template v-if="featureLength() !== 1"
+					>s</template
+				> </strong
 			>.
 		</p>
 		<table class="details">
 			<tbody>
-				<tr v-for="(value, key) in name" :key="key">
+				<tr v-for="(value, key) in summary" :key="key">
 					<th scope="row">{{ key }}</th>
 					<td>{{ value }}</td>
 				</tr>
@@ -45,7 +49,7 @@
 		<div class="features" aria-label="Font layout features">
 			<strong>Layout features</strong>
 			<ul>
-				<li v-for="feature in features" :key="feature">
+				<li v-for="(featureData, feature) in features" :key="feature">
 					<span class="opentype-label">{{ feature }}</span>
 				</li>
 			</ul>

--- a/src/components/report/VariableControls.js
+++ b/src/components/report/VariableControls.js
@@ -2,32 +2,16 @@ export default {
 	props: ["font", "showAxes", "showInstances", "showTitles", "showStyles"],
 	data() {
 		return {
-			activeInstance: "",
-			// ↓ This should come from the font prop, once it's wired up
-			axes: {
-				wdth: {
-					name: "Width",
-					min: 100,
-					max: 900,
-					default: 200,
-					current: 200 // Starts as `default` and changes when slider is pulled
-				},
-				wght: {
-					name: "Weight",
-					min: 1,
-					max: 1000,
-					default: 666,
-					current: 666 // Starts as `default` and changes when slider is pulled
-				}
-			},
-			instances: {
-				"Mono Casual Light": { wdth: 800, wght: 666 },
-				"Mono Casual Light Italic": { wdth: 400, wght: 666 },
-				"Mono Casual Regular": { wdth: 123, wght: 666 }
-			}
+			activeInstance: ""
 		};
 	},
 	computed: {
+		axes() {
+			return this.font.variables.axes;
+		},
+		instances() {
+			return this.font.variables.instances;
+		},
 		variableStyles() {
 			return this.getVariableStyles(this.axes);
 		}


### PR DESCRIPTION
This PR loads fonts via Fondue and updates a few components to use actual font data.
Note that this is a clean branch, that incorporates some changes from https://github.com/Wakamai-Fondue/wakamai-fondue-site/pull/1 that were manually reapplied due to substantial merge conflicts.