### PR TITLE
Load example fonts through URI (experiment)

### DIFF
--- a/src/App.js
+++ b/src/App.js
@@ -6,6 +6,12 @@ import Hero from "./components/Hero.vue";
 import Report from "./components/Report.vue";
 
 export default {
+	created: function() {
+		if (window.location.pathname == "/bungee") {
+			this.getExampleFont("Bungee-Regular.ttf");
+			document.getElementById("report").scrollIntoView();
+		}
+	},
 	components: {
 		Hero,
 		Report


### PR DESCRIPTION
In the most simple way possible, without complex routers and stuff.
Actually works pretty nicely.

To be improved: the WF main screen is in view for a split second,
until the example font has loaded, then quickly scrolls to the
results. So we should either:

- Skip the main screen enitirely and go the results without any
  janky redraw or scroll
- Artificially delay the loading of the example font so the user
  can see the WF main screen, see it "working" and then see it
  scroll to the results