### PR TITLE
Support hot-reload for linked Fondue module

### DIFF
--- a/vue.config.js
+++ b/vue.config.js
@@ -1,5 +1,15 @@
 module.exports = {
   devServer: {
-    disableHostCheck: true
-  }
+    disableHostCheck: true,
+    watchOptions: {
+      ignored: [
+        /node_modules([\\]+|\/)+(?!fondue)/, 
+      ]
+    }
+  },
+  configureWebpack: {
+    resolve: {
+      symlinks: false, // npm link
+    },
+  },
 };


### PR DESCRIPTION
This PR fixes ESLint errors when using a local Fondue engine via `npm link`.

```
Error: Failed to load plugin 'jest' declared in '../wakamai-fondue-engine/.eslintrc.json': Cannot find module 'eslint-plugin-jest'
```