### PR TITLE
Lock engine version in package.json

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -5227,7 +5227,7 @@
     },
     "fondue": {
       "version": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#e297a9cd9168bfdff5e494a1af5c7dec29a2a87f",
-      "from": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#master"
+      "from": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#e297a9cd9168bfdff5e494a1af5c7dec29a2a87f"
     },
     "for-in": {
       "version": "1.0.2",

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
   },
   "dependencies": {
     "core-js": "^3.6.5",
-    "fondue": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#master",
+    "fondue": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#e297a9cd9168bfdff5e494a1af5c7dec29a2a87f",
     "vue": "^2.6.11"
   },
   "devDependencies": {
@@ -25,6 +25,6 @@
     "vue-template-compiler": "^2.6.11"
   },
   "engines": {
-		"node": ">=14"
-	}
+    "node": ">=14"
+  }
 }


### PR DESCRIPTION
To prevent NPM updating to the latest master version, even though the
specific commit was locked in package-lock.json :(

NPM doesn't respect the commit SHA specified in `package-lock.json`, if there's a newer version possible via what is specified in `package.json`. I didn't know this behavior, I'm pretty sure Yarn does not do this.

In any case, to ensure everyone working with this site gets the same engine version, l've now locked down the specific commit in `package.json`. This does mean that if you want to update the engine, you have to manually find the commit SHA you want to update, put this in `package.json` and run `npm i`.