### PR TITLE
Show CPAL data

### DIFF
--- a/src/components/report/Color.css
+++ b/src/components/report/Color.css
@@ -7,6 +7,7 @@
 
 .palette {
 	display: flex;
+	flex-wrap: wrap;
 	margin-top: 1rem;
 }
 

--- a/src/components/report/Color.js
+++ b/src/components/report/Color.js
@@ -3,20 +3,7 @@ export default {
 	props: ["font"],
 	data() {
 		return {
-			palettes: [
-				["#ff0000", "#00ff00", "#666000"],
-				["#123789", "#789123", "#800080"]
-			]
+			palettes: this.font.colorPalettes
 		};
-	},
-	computed: {
-		colorFormat() {
-			const formats = ["COLR"]; // should come from font object
-			if (formats.length === 1) return formats[0];
-			let result = "";
-			result = formats.pop();
-			result = formats.join(", ") + " and " + result;
-			return result;
-		}
 	}
 };

--- a/src/components/report/Color.vue
+++ b/src/components/report/Color.vue
@@ -17,10 +17,14 @@
 			</p>
 			<template v-if="palettes.length">
 				<h3>Palettes</h3>
-				<ul class="palette">
+				<ul
+					class="palette"
+					v-for="(palette, palIndex) in palettes"
+					:key="`pal_${palIndex}`"
+				>
 					<li
-						v-for="color in palettes"
-						:key="color"
+						v-for="(color, colorIndex) in palette"
+						:key="`clr_${palIndex}_${colorIndex}`"
 						:style="{ background: color }"
 					>
 						<span class="label">{{ color }}</span>

--- a/src/components/report/Color.vue
+++ b/src/components/report/Color.vue
@@ -15,16 +15,18 @@
 					The colors are hardcoded in the font.
 				</template>
 			</p>
-			<h3 v-if="true">Palettes</h3>
-			<ul class="palette">
-				<li
-					v-for="color in palettes"
-					:key="color"
-					:style="{ background: color }"
-				>
-					<span class="label">{{ color }}</span>
-				</li>
-			</ul>
+			<template v-if="palettes.length">
+				<h3>Palettes</h3>
+				<ul class="palette">
+					<li
+						v-for="color in palettes"
+						:key="color"
+						:style="{ background: color }"
+					>
+						<span class="label">{{ color }}</span>
+					</li>
+				</ul>
+			</template>
 		</div>
 	</section>
 </template>

--- a/src/components/report/Color.vue
+++ b/src/components/report/Color.vue
@@ -15,14 +15,10 @@
 					The colors are hardcoded in the font.
 				</template>
 			</p>
-			<h3 v-if="palettes.length">Palettes</h3>
-			<ul
-				v-for="palette in palettes"
-				:key="`palette_${palette}`"
-				class="palette"
-			>
+			<h3 v-if="true">Palettes</h3>
+			<ul class="palette">
 				<li
-					v-for="color in palette"
+					v-for="color in palettes"
 					:key="color"
 					:style="{ background: color }"
 				>

--- a/src/components/report/Color.vue
+++ b/src/components/report/Color.vue
@@ -9,7 +9,7 @@
 
 				<template v-if="palettes.length">
 					It has {{ palettes.length }}
-					{{ palettes | pluralize("palette") }}.
+					{{ palettes.length | pluralize("palette") }}.
 				</template>
 				<template v-else>
 					The colors are hardcoded in the font.


### PR DESCRIPTION
In the future we should make WF handle multiple CPAL palettes, but this needs to be supported by the font parser that our engine uses first ;-)

Needs https://github.com/Wakamai-Fondue/wakamai-fondue-engine/pull/20