### PR TITLE
Update engine

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1676,8 +1676,8 @@
       "dev": true
     },
     "@wakamai-fondue/engine": {
-      "version": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#3872d46779e6c6e8aeed122b7395b2eeb50f200e",
-      "from": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#3872d46779e6c6e8aeed122b7395b2eeb50f200e"
+      "version": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#daac51d6fa4e3885ee5224f790872617539fbd6b",
+      "from": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#daac51d6fa4e3885ee5224f790872617539fbd6b"
     },
     "@webassemblyjs/ast": {
       "version": "1.9.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
     "lint": "vue-cli-service lint"
   },
   "dependencies": {
-    "@wakamai-fondue/engine": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#3872d46779e6c6e8aeed122b7395b2eeb50f200e",
+    "@wakamai-fondue/engine": "git+https://github.com/Wakamai-Fondue/wakamai-fondue-engine.git#daac51d6fa4e3885ee5224f790872617539fbd6b",
     "core-js": "^3.6.5",
     "prismjs": "^1.21.0",
     "vue": "^2.6.11",

--- a/src/App.js
+++ b/src/App.js
@@ -1,7 +1,7 @@
 // TODO: Font.js can be defered/lazy loaded, as it will only
 // be needed after user "uploads" a font
 // TODO: deal with multiple fonts
-import { fromDataBuffer } from "@wakamai-fondue/engine/browser";
+import { fromDataBuffer } from "@wakamai-fondue/engine";
 import Hero from "./components/Hero.vue";
 import Report from "./components/Report.vue";
 import Modal from "./components/Modal.vue";

--- a/vue.config.js
+++ b/vue.config.js
@@ -5,6 +5,7 @@ module.exports = {
 			ignored: [/node_modules([\\]+|\/)+(?!@wakamai-fondue\/engine)/]
 		}
 	},
+	transpileDependencies: ["@wakamai-fondue/engine"],
 	configureWebpack: {
 		resolve: {
 			symlinks: false // npm link


### PR DESCRIPTION
This PR contains changes for compatibility with https://github.com/Wakamai-Fondue/wakamai-fondue-engine/pull/27.
Note that the reference to the engine is not yet updated until that PR is merged. For local testing make sure to `npm link`.