### PR TITLE
Fix long inline style strings

### DIFF
--- a/src/components/report/CharGrid.vue
+++ b/src/components/report/CharGrid.vue
@@ -52,7 +52,7 @@
 						</template>
 					</h3>
 
-					<ol class="grid" :style="variableStyles">
+					<ol class="grid" :style="variableStyles | inlinestyle">
 						<!-- Put this back → :class="char.feature ? 'feature' : 'code'" -->
 						<li
 							v-for="char in cat.chars"
@@ -73,7 +73,7 @@
 				</div>
 			</template>
 
-			<ol class="grid" :style="variableStyles" v-if="!showCategories">
+			<ol class="grid" :style="variableStyles | inlinestyle" v-if="!showCategories">
 				<!-- Put this back → :class="char.feature ? 'feature' : 'code'" -->
 				<li v-for="char in chars" :key="char" class="code">
 					<span class="char" v-html="entitify(char)"></span>

--- a/src/components/report/CharGrid.vue
+++ b/src/components/report/CharGrid.vue
@@ -73,7 +73,11 @@
 				</div>
 			</template>
 
-			<ol class="grid" :style="variableStyles | inlinestyle" v-if="!showCategories">
+			<ol
+				class="grid"
+				:style="variableStyles | inlinestyle"
+				v-if="!showCategories"
+			>
 				<!-- Put this back → :class="char.feature ? 'feature' : 'code'" -->
 				<li v-for="char in chars" :key="char" class="code">
 					<span class="char" v-html="entitify(char)"></span>

--- a/src/components/report/Tester.vue
+++ b/src/components/report/Tester.vue
@@ -10,7 +10,9 @@
 				spellcheck="false"
 				dir="auto"
 				contenteditable
-				:style="`${variableStyles}${featureStyles}${textStyles}`"
+				:style="
+					`${variableStyles}${featureStyles}${textStyles}` | inlinestyle
+				"
 				:lang="language"
 			>
 				<p v-if="customText">

--- a/src/components/report/Tester.vue
+++ b/src/components/report/Tester.vue
@@ -11,7 +11,8 @@
 				dir="auto"
 				contenteditable
 				:style="
-					`${variableStyles}${featureStyles}${textStyles}` | inlinestyle
+					`${variableStyles}${featureStyles}${textStyles}`
+						| inlinestyle
 				"
 				:lang="language"
 			>

--- a/src/components/report/Variable.vue
+++ b/src/components/report/Variable.vue
@@ -5,7 +5,7 @@
 			<div
 				contenteditable
 				class="variable-tester"
-				:style="variableStyles"
+				:style="variableStyles | inlinestyle"
 			>
 				The melting cheese & bread explode in a quick wave of joy: “1,
 				2, 3… zen!”

--- a/src/filters.js
+++ b/src/filters.js
@@ -21,3 +21,8 @@ Vue.filter("capitalize", function(value) {
 	value = value.toString();
 	return value.charAt(0).toUpperCase() + value.slice(1);
 });
+
+// Change formatted, human-friendly CSS to inline-friendly CSS
+Vue.filter("inlinestyle", function(value) {
+	return value.replace(/\n/g, "");
+});


### PR DESCRIPTION
If there are many properties, we add some poor man's formatting
by injecting newlines and "tabs". This doesn't work when the
same string is used for inline styles.

I didn't notice this before as I was apparently testing with
fonts without many features/axes :D

Decided to introduce a small filter so we can keep the poor man's
formatting.