### PR TITLE
Show GSUB features

### DIFF
--- a/src/components/report/CharGrid.vue
+++ b/src/components/report/CharGrid.vue
@@ -79,7 +79,7 @@
 				v-if="!showCategories"
 			>
 				<!-- Put this back → :class="char.feature ? 'feature' : 'code'" -->
-				<li v-for="char in chars" :key="char" class="code">
+				<li v-for="char in chars" :key="`${char}`" class="code">
 					<span class="char" v-html="entitify(char)"></span>
 					<span class="label" v-if="!char.feature">{{ char }}</span>
 					<!--

--- a/src/components/report/Features.css
+++ b/src/components/report/Features.css
@@ -30,6 +30,10 @@
 	color: var(--green);
 }
 
+.flip-state [disabled]+span {
+	color: var(--unlighterer-grey);
+}
+
 .required-features li,
 .feature-control {
 	display: flex;
@@ -39,6 +43,15 @@
 .chars {
 	font-family: wakamai-fondue, monospace;
 	font-size: 1.5rem;
+	background: var(--light-grey);
+	padding: 0.5rem;
+	margin-top: 0.5rem;
+	overflow: hidden;
+}
+
+.no-chars {
+	font-style: italic;
+	color: var(--unlighterer-grey);
 	background: var(--light-grey);
 	padding: 0.5rem;
 	margin-top: 0.5rem;

--- a/src/components/report/Features.js
+++ b/src/components/report/Features.js
@@ -2,23 +2,39 @@ export default {
 	props: ["font"],
 	data() {
 		return {
-			features: this.font.features,
-			chars: ["a", "b", "c", "d", "e", "f"],
 			currentStates: []
 		};
 	},
 	computed: {
 		optionalFeatures() {
-			return this.features.filter(f => f.state !== "fixed");
+			return this.font.features.filter(f => f.state !== "fixed");
 		},
 		requiredFeatures() {
-			return this.features.filter(f => f.state === "fixed");
+			return this.font.features.filter(f => f.state === "fixed");
 		},
 		hasRequiredFeatures() {
 			return this.requiredFeatures.length > 0;
 		},
 		hasOptionalFeatures() {
 			return this.optionalFeatures.length > 0;
+		},
+		featureChars() {
+			// Try to return the "best" layout features
+			if (
+				"DFLT" in this.font.featureChars &&
+				"dflt" in this.font.featureChars["DFLT"]
+			) {
+				return this.font.featureChars["DFLT"]["dflt"];
+			} else if (
+				"latn" in this.font.featureChars &&
+				"dflt" in this.font.featureChars["latn"]
+			) {
+				return this.font.featureChars["latn"]["dflt"];
+			} else {
+				// If all else fails, return first
+				const first = Object.keys(this.font.featureChars)[0];
+				return Object.values(this.font.featureChars[first])[0];
+			}
 		}
 	},
 	methods: {

--- a/src/components/report/Features.vue
+++ b/src/components/report/Features.vue
@@ -40,25 +40,40 @@
 						class="state"
 						:class="feature.state === 'on' ? 'on' : 'off'"
 					>
-						<strong v-if="feature.state === 'on'">on</strong>
-						<strong v-else>off</strong>
+						<strong v-if="feature.state === 'on'">On</strong>
+						<strong v-else>Off</strong>
 						by default
 					</span>
-					<label>
+					<label class="flip-state">
 						<input
 							type="checkbox"
 							@change="flipState(feature.tag)"
+							:disabled="!featureChars[feature.tag]"
 							checked
-						/>Show
+						/><span>show</span>
 					</label>
 				</div>
 				<div
+					v-if="featureChars[feature.tag]"
 					class="chars"
 					:style="getFeatureStyle(feature.tag)"
 					contenteditable
 					spellcheck="false"
 				>
-					<template v-for="char in chars">{{ char }}</template>
+					<template v-for="char in featureChars[feature.tag]">
+						{{ char }}
+					</template>
+				</div>
+				<div
+					v-else
+					class="no-chars"
+					:style="getFeatureStyle(feature.tag)"
+				>
+					We couldn’t trace back this feature’s glyphs to characters.
+					This means this feature applies only to characters that have
+					been processed by another layout feature first. (Or, since
+					this is the beta, we have't implemented this lookup type
+					yet!)
 				</div>
 			</div>
 		</div>


### PR DESCRIPTION
This will show lookup types 1 (single substitutions) and 4 (liga-
tures) for now. This is okay for a beta, but we should add the
rest of the lookups soon.

TODO (after beta release):
- Better communication when no glyphs could be mapped to characters,
  e.g. with chained features
- Should we mention how many glyphs-without-char-mapping there are?