### PR TITLE
Turn offable axes

### DIFF
--- a/src/components/report/FeatureControls.css
+++ b/src/components/report/FeatureControls.css
@@ -9,6 +9,7 @@
 .feature-controls label {
 	margin-bottom: var(--small-margin);
 	display: flex;
+	cursor: pointer;
 }
 
 .feature-description {

--- a/src/components/report/FeatureControls.css
+++ b/src/components/report/FeatureControls.css
@@ -3,10 +3,10 @@
 }
 
 .feature-controls.long ul {
-	columns: 2;
+	columns: 3;
 }
 
-.feature-controls li {
+.feature-controls label {
 	margin-bottom: var(--small-margin);
 	display: flex;
 }
@@ -25,15 +25,6 @@
 	text-overflow: ellipsis;
 }
 
-.buttons {
-	white-space: nowrap;
-	margin-right: 1rem;
-}
-
-.buttons .button {
-	display: none;
-}
-
 /* TODO: componentalizationreuse */
 .button {
 	padding: 0.25rem 0.5rem;
@@ -48,26 +39,18 @@
 	min-width: 4.75em;
 	transition: background 100ms;
 	user-select: none;
+	color: white;
+	margin-right: var(--small-margin);
 }
 
-.button:hover {
-	background-color: var(--unlighterer-grey);
-}
-
-.status-true .button-on {
-	display: inline-block;
+.button-on {
 	background: var(--green);
-	color: white;
 }
 
-.status-false .button-off {
-	display: inline-block;
+.button-off {
 	background: var(--red);
-	color: white;
 }
 
-.status-null .button-default {
-	display: inline-block;
+.button-default {
 	background: var(--dark-grey);
-	color: white;
 }

--- a/src/components/report/FeatureControls.js
+++ b/src/components/report/FeatureControls.js
@@ -8,7 +8,7 @@ export default {
 	data() {
 		return {
 			features: this.font.features,
-			currentStates: []
+			currentStates: {}
 		};
 	},
 	computed: {
@@ -23,12 +23,9 @@ export default {
 		this.updateStyles();
 	},
 	methods: {
-		getClass(feature) {
-			return `status-${this.currentStates[feature]}`;
-		},
-		flipState(feature, state) {
+		flipState(feature) {
 			const states = [true, false, null];
-			const currentIndex = states.indexOf(state);
+			const currentIndex = states.indexOf(this.currentStates[feature]);
 			const nextIndex = (currentIndex + 1) % states.length;
 			this.currentStates[feature] = states[nextIndex];
 			this.updateStyles();

--- a/src/components/report/FeatureControls.vue
+++ b/src/components/report/FeatureControls.vue
@@ -5,10 +5,10 @@
 			<li
 				v-for="feature in optionalFeatures"
 				:key="`featcont_${feature.tag}`"
-				:class="getClass(feature.tag)"
 			>
-				<span class="buttons">
+				<label>
 					<button
+						v-if="currentStates[feature.tag] === true"
 						type="button"
 						class="button button-on"
 						@click="flipState(feature.tag, true)"
@@ -16,6 +16,7 @@
 						On
 					</button>
 					<button
+						v-if="currentStates[feature.tag] === false"
 						type="button"
 						class="button button-off"
 						@click="flipState(feature.tag, false)"
@@ -23,19 +24,20 @@
 						Off
 					</button>
 					<button
+						v-if="currentStates[feature.tag] === null"
 						type="button"
 						class="button button-default"
 						@click="flipState(feature.tag, null)"
 					>
 						Default
 					</button>
-				</span>
-				<span class="feature-description">
-					<span class="opentype-label">{{ feature.tag }}</span>
-					<span class="feature-name" :title="feature.name">{{
-						feature.name
-					}}</span>
-				</span>
+					<span class="feature-description">
+						<span class="opentype-label">{{ feature.tag }}</span>
+						<span class="feature-name" :title="feature.name">{{
+							feature.name
+						}}</span>
+					</span>
+				</label>
 			</li>
 		</ul>
 	</div>

--- a/src/components/report/VariableControls.css
+++ b/src/components/report/VariableControls.css
@@ -7,7 +7,7 @@
 	display: grid;
 	align-items: center;
 	grid-template-columns:
-		12em
+		18em
 		4em
 		1fr
 		4em
@@ -26,7 +26,7 @@
 }
 
 /* TODO: componentalizationreuse */
-.button {
+.reset-button {
 	padding: 0.25rem 0.5rem;
 	border-radius: 0.2rem;
 	margin: 0;
@@ -83,4 +83,31 @@
 .instances-dropdown-label {
 	display: inline-block;
 	width: 16em;
+}
+
+/* TODO: componentalizationreuse */
+.button-on,
+.button-off {
+	padding: 0.25rem 0.5rem;
+	border-radius: 0.2rem;
+	margin: 0;
+	border: 0;
+	background: none;
+	font-size: 0.85rem;
+	background: var(--unlighter-grey);
+	color: var(--dark-grey);
+	cursor: pointer;
+	min-width: 4.75em;
+	transition: background 100ms;
+	user-select: none;
+	color: white;
+	margin-right: var(--small-margin);
+}
+
+.button-on {
+	background: var(--green);
+}
+
+.button-off {
+	background: var(--red);
 }

--- a/src/components/report/VariableControls.css
+++ b/src/components/report/VariableControls.css
@@ -2,7 +2,7 @@
 	margin-top: 2rem;
 }
 
-.axis-slider {
+.axis-slider-container {
 	margin-bottom: var(--small-margin);
 	display: grid;
 	align-items: center;
@@ -15,6 +15,16 @@
 		auto;
 }
 
+.axis-slider-container label {
+	cursor: pointer;
+}
+
+.disabled .axis-min,
+.disabled .axis-max,
+.disabled .axis-current {
+	color: var(--unlighterer-grey);
+}
+
 .axis-name {
 	white-space: nowrap;
 	overflow: hidden;
@@ -23,6 +33,15 @@
 
 .axis-min {
 	text-align: right;
+}
+
+.axis-slider {
+	vertical-align: middle;
+	padding: 0 0.5rem 0 0.25rem;
+}
+
+.axis-slider input {
+	width: 100%;
 }
 
 /* TODO: componentalizationreuse */
@@ -37,8 +56,11 @@
 	color: white;
 	cursor: pointer;
 }
+.reset-button[disabled] {
+	background: var(--unlighterer-grey);
+}
 
-.axis-slider button.hide {
+.reset-button.hide {
 	opacity: 0;
 	pointer-events: none;
 }
@@ -50,6 +72,12 @@
 }
 
 .instance-button {
+	padding: 0.25rem 0.5rem;
+	border-radius: 0.2rem;
+	margin: 0;
+	border: 0;
+	background: none;
+	cursor: pointer;
 	width: 100%;
 	background: var(--yellow);
 	color: black;

--- a/src/components/report/VariableControls.js
+++ b/src/components/report/VariableControls.js
@@ -99,11 +99,11 @@ export default {
 				return "1";
 			}
 		},
-		flipState(axis) {
+		flipState(axis, force) {
 			this.$set(
 				this.currentStates,
 				axis,
-				this.currentStates[axis] === false
+				force || this.currentStates[axis] === false
 			);
 			this.updateStyles();
 		}

--- a/src/components/report/VariableControls.js
+++ b/src/components/report/VariableControls.js
@@ -9,7 +9,8 @@ export default {
 		return {
 			activeInstance: "",
 			axes: this.font.variable.axes,
-			instances: this.font.variable.instances
+			instances: this.font.variable.instances,
+			currentStates: {}
 		};
 	},
 	computed: {
@@ -64,11 +65,13 @@ export default {
 			let counter = 0;
 			let maxProps = 6;
 			for (const axis of Object.values(this.axes)) {
-				styles += `${glue} "${axis.id}" ${axis.current}`;
-				glue = ",";
-				// Poor man's code formatting
-				if (++counter % maxProps === 0) {
-					glue = `,\n                        `;
+				if (this.currentStates[axis.id] !== false) {
+					styles += `${glue} "${axis.id}" ${axis.current}`;
+					glue = ",";
+					// Poor man's code formatting
+					if (++counter % maxProps === 0) {
+						glue = `,\n                        `;
+					}
 				}
 			}
 			if (styles) {
@@ -95,6 +98,14 @@ export default {
 			} else {
 				return "1";
 			}
+		},
+		flipState(axis) {
+			this.$set(
+				this.currentStates,
+				axis,
+				this.currentStates[axis] === false
+			);
+			this.updateStyles();
 		}
 	}
 };

--- a/src/components/report/VariableControls.vue
+++ b/src/components/report/VariableControls.vue
@@ -3,45 +3,56 @@
 		<div v-if="showAxes" class="axes">
 			<h3 v-if="showTitles">Variable axes</h3>
 			<ul class="axes-sliders">
-				<li class="axis-slider" v-for="(axis, tag) in axes" :key="tag">
-					<span>
+				<li
+					class="axis-slider-container"
+					:class="currentStates[axis.id] === false ? 'disabled' : ''"
+					v-for="(axis, tag) in axes"
+					:key="tag"
+				>
+					<label>
 						<button
 							v-if="currentStates[axis.id] !== false"
 							type="button"
-							@click="flipState(axis.id)"
 							class="button-on"
+							@click="flipState(axis.id)"
 						>
 							On
 						</button>
 						<button
 							v-if="currentStates[axis.id] === false"
 							type="button"
-							@click="flipState(axis.id)"
 							class="button-off"
+							@click="flipState(axis.id)"
 						>
 							Off
 						</button>
 						<span class="opentype-label">{{ axis.id }}</span>
 						<span class="axis-name">{{ axis.name }}</span>
-					</span>
+					</label>
 					<span class="axis-min">{{ axis.min }}</span>
-					<input
-						type="range"
-						:name="axis.id"
-						:step="getBestStep(axis)"
-						:min="axis.min"
-						:max="axis.max"
-						:disabled="currentStates[axis.id] === false"
-						v-model.number="axis.current"
-						@input="updateStyles()"
-					/>
-					<span>{{ axis.max }}</span>
-					<strong>{{ axis.current }}</strong>
+					<span
+						class="axis-slider"
+						@mousedown="flipState(axis.id, true)"
+					>
+						<input
+							type="range"
+							:name="axis.id"
+							:step="getBestStep(axis)"
+							:min="axis.min"
+							:max="axis.max"
+							:disabled="currentStates[axis.id] === false"
+							v-model.number="axis.current"
+							@input="updateStyles()"
+						/>
+					</span>
+					<span class="axis-max">{{ axis.max }}</span>
+					<strong class="axis-current">{{ axis.current }}</strong>
 					<button
 						type="button"
 						class="reset-button"
 						:class="axis.current !== axis.default ? 'show' : 'hide'"
 						:tabindex="axis.current !== axis.default ? 0 : -1"
+						:disabled="currentStates[axis.id] === false"
 						@click="resetAxis(tag)"
 					>
 						Reset

--- a/src/components/report/VariableControls.vue
+++ b/src/components/report/VariableControls.vue
@@ -5,6 +5,22 @@
 			<ul class="axes-sliders">
 				<li class="axis-slider" v-for="(axis, tag) in axes" :key="tag">
 					<span>
+						<button
+							v-if="currentStates[axis.id] !== false"
+							type="button"
+							@click="flipState(axis.id)"
+							class="button-on"
+						>
+							On
+						</button>
+						<button
+							v-if="currentStates[axis.id] === false"
+							type="button"
+							@click="flipState(axis.id)"
+							class="button-off"
+						>
+							Off
+						</button>
 						<span class="opentype-label">{{ axis.id }}</span>
 						<span class="axis-name">{{ axis.name }}</span>
 					</span>
@@ -15,6 +31,7 @@
 						:step="getBestStep(axis)"
 						:min="axis.min"
 						:max="axis.max"
+						:disabled="currentStates[axis.id] === false"
 						v-model.number="axis.current"
 						@input="updateStyles()"
 					/>
@@ -22,7 +39,7 @@
 					<strong>{{ axis.current }}</strong>
 					<button
 						type="button"
-						class="button"
+						class="reset-button"
 						:class="axis.current !== axis.default ? 'show' : 'hide'"
 						:tabindex="axis.current !== axis.default ? 0 : -1"
 						@click="resetAxis(tag)"


### PR DESCRIPTION
Font with axes set to the font's default can look different that when set to the browser's default.

So Wakamai Fondue should offer a way to _not set_ a specific axis, so the browser is given a chance to fill in its own default. This way you can better see how the font will behave in a browser environment.

Context: https://twitter.com/PixelAmbacht/status/1327165110868176897