### PR TITLE
Add basic link between font-size and opsz

### DIFF
--- a/src/components/report/TextControls.css
+++ b/src/components/report/TextControls.css
@@ -13,6 +13,19 @@
 	margin-left: var(--small-margin);
 }
 
+.font-size {
+	display: flex;
+	align-items: flex-start;
+}
+
+.font-size-slider {
+	width: 100%;
+}
+
+.optical-size-link {
+	font-size: 0.85rem;
+}
+
 /* TODO: componentalizationreuse */
 .button {
 	padding: 0.25rem 0.5rem;

--- a/src/components/report/TextControls.js
+++ b/src/components/report/TextControls.js
@@ -21,6 +21,7 @@ export default {
 		}
 	},
 	mounted: function() {
+		this.$root.$on("unlinkOpticalSize", this.unlinkOpticalSize);
 		this.updateStyles();
 	},
 	methods: {
@@ -39,6 +40,13 @@ export default {
 		},
 		setLanguage: function(language) {
 			this.$emit("updateLanguage", language);
+		},
+		toggleOpticalSizeLink() {
+			this.linkOpticalSize = !this.linkOpticalSize;
+			this.updateStyles();
+		},
+		unlinkOpticalSize: function() {
+			this.linkOpticalSize = false;
 		}
 	}
 };

--- a/src/components/report/TextControls.js
+++ b/src/components/report/TextControls.js
@@ -23,6 +23,7 @@ export default {
 		},
 		updateStyles: function() {
 			this.$emit("updateTextStyles", this.getTextStyles());
+			this.$root.$emit("updateOpticalSize", this.fontSize);
 		},
 		getTextStyles: function() {
 			return `font-size: ${this.fontSize}px;\ntext-align: ${this.textAlign};`;

--- a/src/components/report/TextControls.js
+++ b/src/components/report/TextControls.js
@@ -5,12 +5,19 @@ export default {
 			fontSize: 24,
 			textAlign: "left",
 			activeLanguage: null,
-			languages: this.font.languageSystems
+			languages: this.font.languageSystems,
+			linkOpticalSize: false
 		};
 	},
 	computed: {
 		hasLocalization() {
 			return this.font.languageSystems.length > 0;
+		},
+		hasOpticalSize() {
+			return (
+				this.font.variable !== undefined &&
+				this.font.variable.axes.find(o => o.id === "opsz") !== undefined
+			);
 		}
 	},
 	mounted: function() {
@@ -23,7 +30,9 @@ export default {
 		},
 		updateStyles: function() {
 			this.$emit("updateTextStyles", this.getTextStyles());
-			this.$root.$emit("updateOpticalSize", this.fontSize);
+			if (this.hasOpticalSize && this.linkOpticalSize) {
+				this.$root.$emit("updateOpticalSize", this.fontSize);
+			}
 		},
 		getTextStyles: function() {
 			return `font-size: ${this.fontSize}px;\ntext-align: ${this.textAlign};`;

--- a/src/components/report/TextControls.js
+++ b/src/components/report/TextControls.js
@@ -12,12 +12,6 @@ export default {
 	computed: {
 		hasLocalization() {
 			return this.font.languageSystems.length > 0;
-		},
-		hasOpticalSize() {
-			return (
-				this.font.variable !== undefined &&
-				this.font.variable.axes.find(o => o.id === "opsz") !== undefined
-			);
 		}
 	},
 	mounted: function() {
@@ -31,7 +25,7 @@ export default {
 		},
 		updateStyles: function() {
 			this.$emit("updateTextStyles", this.getTextStyles());
-			if (this.hasOpticalSize && this.linkOpticalSize) {
+			if (this.font.hasOpticalSize && this.linkOpticalSize) {
 				this.$root.$emit("updateOpticalSize", this.fontSize);
 			}
 		},

--- a/src/components/report/TextControls.vue
+++ b/src/components/report/TextControls.vue
@@ -1,9 +1,13 @@
 <template>
 	<div class="text-controls">
-		<div>
-			<label>
+		<div class="font-size">
+			<label for="font-size-slider">
 				Font size
+			</label>
+			<div>
 				<input
+					id="font-size-slider"
+					class="font-size-slider"
 					type="range"
 					min="8"
 					max="100"
@@ -11,7 +15,15 @@
 					v-model.number="fontSize"
 					@input="updateStyles()"
 				/>
-			</label>
+				<label class="optical-size-link" v-if="hasOpticalSize">
+					<input
+						type="checkbox"
+						name="font-size"
+						v-model="linkOpticalSize"
+					/>
+					Link to optical size
+				</label>
+			</div>
 		</div>
 		<div v-if="hasLocalization">
 			<label>

--- a/src/components/report/TextControls.vue
+++ b/src/components/report/TextControls.vue
@@ -11,15 +11,17 @@
 					type="range"
 					min="8"
 					max="100"
-					step="0.01"
+					step="1"
 					v-model.number="fontSize"
 					@input="updateStyles()"
 				/>
+
 				<label class="optical-size-link" v-if="hasOpticalSize">
 					<input
 						type="checkbox"
 						name="font-size"
-						v-model="linkOpticalSize"
+						:checked="linkOpticalSize"
+						@input="toggleOpticalSizeLink()"
 					/>
 					Link to optical size
 				</label>

--- a/src/components/report/TextControls.vue
+++ b/src/components/report/TextControls.vue
@@ -16,7 +16,7 @@
 					@input="updateStyles()"
 				/>
 
-				<label class="optical-size-link" v-if="hasOpticalSize">
+				<label class="optical-size-link" v-if="font.hasOpticalSize">
 					<input
 						type="checkbox"
 						name="font-size"

--- a/src/components/report/VariableControls.js
+++ b/src/components/report/VariableControls.js
@@ -27,8 +27,8 @@ export default {
 	},
 	methods: {
 		updateOpticalSize(fontSize) {
-			const targetAxis = this.axes.find(o => o.id === "opsz");
-			if (targetAxis) {
+			if (this.font.hasOpticalSize) {
+				const targetAxis = this.axes.find(o => o.id === "opsz");
 				const opszValue = Math.min(
 					Math.max(targetAxis.min, fontSize),
 					targetAxis.max

--- a/src/components/report/VariableControls.js
+++ b/src/components/report/VariableControls.js
@@ -22,11 +22,29 @@ export default {
 		}
 	},
 	mounted: function() {
+		this.$root.$on("updateOpticalSize", this.linkOpticalSize);
 		this.updateStyles();
 	},
 	methods: {
-		resetAxis: function(axis) {
-			this.axes[axis].current = this.axes[axis].default;
+		linkOpticalSize(fontSize) {
+			const targetAxis = this.axes.find(o => o.id === "opsz");
+			if (targetAxis) {
+				const opszValue = Math.min(
+					Math.max(targetAxis.min, fontSize),
+					targetAxis.max
+				);
+				this.resetAxis("opsz", opszValue);
+			}
+		},
+		resetAxis: function(axis, value) {
+			const targetAxis = this.axes.find(o => o.id === axis);
+			if (value !== undefined) {
+				value = Math.min(
+					Math.max(targetAxis.min, value),
+					targetAxis.max
+				);
+			}
+			targetAxis.current = value || targetAxis.default;
 			this.updateStyles();
 		},
 		selectInstance: function(instance) {

--- a/src/components/report/VariableControls.vue
+++ b/src/components/report/VariableControls.vue
@@ -42,7 +42,7 @@
 							:max="axis.max"
 							:disabled="currentStates[axis.id] === false"
 							v-model.number="axis.current"
-							@input="updateStyles()"
+							@input="updateStyles(axis.id)"
 						/>
 					</span>
 					<span class="axis-max">{{ axis.max }}</span>
@@ -53,7 +53,7 @@
 						:class="axis.current !== axis.default ? 'show' : 'hide'"
 						:tabindex="axis.current !== axis.default ? 0 : -1"
 						:disabled="currentStates[axis.id] === false"
-						@click="resetAxis(tag)"
+						@click="resetAxis(axis.id)"
 					>
 						Reset
 					</button>


### PR DESCRIPTION
Allow users to link optical size directly to font size. This way the optical size gets set to the value matching the font-size. When unlinked, they can be set independently (which is probably not what you want in a typesetting environment, but it's a good feature if you want to see what your font can do).