### PR TITLE
Don't fail when no feature characters have been reported

### DIFF
--- a/src/components/report/FeatureControls.js
+++ b/src/components/report/FeatureControls.js
@@ -31,7 +31,7 @@ export default {
 				"dflt" in this.font.featureChars["latn"]
 			) {
 				return this.font.featureChars["latn"]["dflt"];
-			} else if(Object.keys(this.font.featureChars).length > 0) {
+			} else if (Object.keys(this.font.featureChars).length > 0) {
 				// If all else fails, return first
 				const first = Object.keys(this.font.featureChars)[0];
 				return Object.values(this.font.featureChars[first])[0];

--- a/src/components/report/FeatureControls.js
+++ b/src/components/report/FeatureControls.js
@@ -31,10 +31,12 @@ export default {
 				"dflt" in this.font.featureChars["latn"]
 			) {
 				return this.font.featureChars["latn"]["dflt"];
-			} else {
+			} else if(Object.keys(this.font.featureChars).length > 0) {
 				// If all else fails, return first
 				const first = Object.keys(this.font.featureChars)[0];
 				return Object.values(this.font.featureChars[first])[0];
+			} else {
+				return {};
 			}
 		}
 	},

--- a/src/components/report/Features.js
+++ b/src/components/report/Features.js
@@ -30,7 +30,7 @@ export default {
 				"dflt" in this.font.featureChars["latn"]
 			) {
 				return this.font.featureChars["latn"]["dflt"];
-			} else if(Object.keys(this.font.featureChars).length > 0) {
+			} else if (Object.keys(this.font.featureChars).length > 0) {
 				// If all else fails, return first
 				const first = Object.keys(this.font.featureChars)[0];
 				return Object.values(this.font.featureChars[first])[0];

--- a/src/components/report/Features.js
+++ b/src/components/report/Features.js
@@ -30,10 +30,12 @@ export default {
 				"dflt" in this.font.featureChars["latn"]
 			) {
 				return this.font.featureChars["latn"]["dflt"];
-			} else {
+			} else if(Object.keys(this.font.featureChars).length > 0) {
 				// If all else fails, return first
 				const first = Object.keys(this.font.featureChars)[0];
 				return Object.values(this.font.featureChars[first])[0];
+			} else {
+				return {};
 			}
 		}
 	},


### PR DESCRIPTION
E.g. when all features are for glyphs replaces in previous lookups.
This is currently the case for `kern`, for instance.

This code will be replaced soon. The "best" feature chars should
be decided by the Engine, or through user input. The latter could
be something like a dropdown where you chose the script, or the
accompanying HTML language tag.