### PR TITLE
Enable running checks locally

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -22,5 +22,5 @@ jobs:
           node-version-file: .tool-versions
           cache: npm
       - run: NODE_ENV=development npm install
-      - run: npm run lint -- --no-fix --max-warnings=0
+      - run: npm run lint:check
       - run: npm run build

--- a/package.json
+++ b/package.json
@@ -5,6 +5,7 @@
   "scripts": {
     "serve": "vue-cli-service serve",
     "build": "vue-cli-service build",
+    "lint:check": "vue-cli-service lint --no-fix --max-warnings=0",
     "lint": "vue-cli-service lint"
   },
   "dependencies": {


### PR DESCRIPTION
## Why?

So that all the CI steps can be consistently reproducible locally.

## What?

Add a `lint:check` script that does what we had in CI.