### PR TITLE
refactor: use composition API

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -1,3 +1,24 @@
+<template>
+	<main
+		id="app"
+		@drop.prevent="getFont"
+		@dragover.prevent="dragStatus(true)"
+		@mouseout="dragStatus(false)"
+		@keydown.esc="toggleInfoModal(true)"
+		tabindex="0"
+		:class="{ dragging, working }"
+	>
+		<TheFondue
+			@getFont="getFont"
+			@getExampleFont="getExampleFont"
+			@toggleInfoModal="toggleInfoModal"
+			:error="error"
+		/>
+		<FontReport :font="font" :isExamplefont="isExamplefont" />
+		<InfoModal v-if="showInfoModal" @toggleInfoModal="toggleInfoModal" />
+	</main>
+</template>
+
 <script setup>
 import { nextTick, onMounted, ref } from "vue";
 
@@ -144,27 +165,6 @@ function toggleInfoModal(forceClose) {
 	}
 }
 </script>
-
-<template>
-	<main
-		id="app"
-		@drop.prevent="getFont"
-		@dragover.prevent="dragStatus(true)"
-		@mouseout="dragStatus(false)"
-		@keydown.esc="toggleInfoModal(true)"
-		tabindex="0"
-		:class="{ dragging, working }"
-	>
-		<TheFondue
-			@getFont="getFont"
-			@getExampleFont="getExampleFont"
-			@toggleInfoModal="toggleInfoModal"
-			:error="error"
-		/>
-		<FontReport :font="font" :isExamplefont="isExamplefont" />
-		<InfoModal v-if="showInfoModal" @toggleInfoModal="toggleInfoModal" />
-	</main>
-</template>
 
 <style>
 :root {

--- a/src/components/FontReport.vue
+++ b/src/components/FontReport.vue
@@ -33,5 +33,10 @@ export default {
 		StyleSheet,
 		SiteFooter,
 	},
+	updated() {
+		if (this.font) {
+			document.getElementById("report").scrollIntoView();
+		}
+	},
 };
 </script>


### PR DESCRIPTION
To gauge whether it makes sense to use the Composition API. This is what the App.vue would look like.
By convention, script - template - style is the usual order.

I made a small tweak to FontReport so the App.vue wouldn't need to know about the DOM here.