### PR TITLE
refactor: let Vue handle the scrolling

### DIFF
--- a/src/App.vue
+++ b/src/App.vue
@@ -78,7 +78,6 @@ export default {
 					that.font = fondue;
 					that.$nextTick(() => {
 						that.working = false;
-						document.getElementById("report").scrollIntoView();
 					});
 				})
 				.catch(function () {

--- a/src/components/FontReport.vue
+++ b/src/components/FontReport.vue
@@ -33,5 +33,10 @@ export default {
 		StyleSheet,
 		SiteFooter,
 	},
+	updated() {
+		if (this.font) {
+			document.getElementById("report")?.scrollIntoView();
+		}
+	},
 };
 </script>


### PR DESCRIPTION
Given Vue has a reactivity engine baked into it, assigning the font variable will cause FontReport to learn about the change. Since it is responsible for the element with id of report it should be the one in charge of scrolling itself into view.

Follow up of #230 