### PR TITLE
fix: prevent crash on Cormorant-Bold.ttf

### DIFF
--- a/src/components/report/OpenTypeFeatures.vue
+++ b/src/components/report/OpenTypeFeatures.vue
@@ -101,7 +101,7 @@
 						v-if="
 							featureChars[feature.tag]['summary'][
 								'uniqueCombinations'
-							].length
+							]?.length
 						"
 					>
 						<span


### PR DESCRIPTION
Oopsi.

https://github.com/CatharsisFonts/Cormorant/blob/master/fonts/ttf/Cormorant-Bold.ttf broke it.