### PR TITLE
fix: prevent overflow on small viewports

### DIFF
--- a/src/components/report/FontSummary.vue
+++ b/src/components/report/FontSummary.vue
@@ -171,6 +171,7 @@ export default {
 	padding-top: var(--small-margin);
 	padding-right: 1em;
 	text-align: left;
+	white-space: nowrap;
 	text-transform: capitalize;
 	vertical-align: top;
 }


### PR DESCRIPTION
There was some whitespace on the right hand of the viewport. I could identify two causes and suggest fixes to them.

The `white-space: nowrap` was introduced in this commit: https://github.com/Wakamai-Fondue/wakamai-fondue-site/commit/1730667e4a69ddd1eda90ad71477886b37a994c3

The commit summary makes me believe that it should be fine to allow wrapping.

Follow-up on #244 