### PR TITLE
Use the "both" format

### DIFF
--- a/src/components/report/OpenTypeFeatures.vue
+++ b/src/components/report/OpenTypeFeatures.vue
@@ -135,13 +135,9 @@
 						<CopyToClipboard
 							:content="getFeatureCSS(feature.tag)"
 						/>
-						<Prism
-							language="css"
-							:key="`code_${feature.tag}_${
-								currentStates[feature.tag]
-							}`"
-							>{{ getFeatureCSS(feature.tag) }}</Prism
-						>
+						<Prism language="css" :key="`code_${feature.tag}`">{{
+							getFeatureCSS(feature.tag)
+						}}</Prism>
 					</div>
 				</template>
 				<div
@@ -237,7 +233,8 @@ export default {
 		},
 		getFeatureCSS(feature) {
 			return this.font.featureCSS(feature, {
-				value: this.currentStates[feature] ?? 1,
+				value: 1,
+				format: "both",
 			});
 		},
 		getCombinations(feature) {


### PR DESCRIPTION
This PR keeps the example CSS always in the "on" state, regardless of whether the feature is enabled in the WF site.